### PR TITLE
fix(cli): correctly consider --inspect/--inspect-brk options without value

### DIFF
--- a/src/create-cli.ts
+++ b/src/create-cli.ts
@@ -98,12 +98,14 @@ export function createCli(argv: string[]) {
                         group: 'Server',
                         type: 'number',
                         describe: 'Opens a port for debugging',
+                        coerce: (arg) => (arg === undefined ? null : arg),
                     })
                     .option('inspect-brk', {
                         group: 'Server',
                         type: 'number',
                         describe:
                             'Opens a port for debugging. Will block until debugger is attached',
+                        coerce: (arg) => (arg === undefined ? null : arg),
                     })
                     .option('entry-filter', {
                         group: 'Client',


### PR DESCRIPTION
Turns on debug mode if options --inspect/--inspect-brk are passed without a value