### PR TITLE
fix: disable sourceMap for debug mode

### DIFF
--- a/src/common/typescript/watch.ts
+++ b/src/common/typescript/watch.ts
@@ -27,7 +27,12 @@ export function watch(
 
     const host = ts.createWatchCompilerHost(
         configPath,
-        {noEmitOnError: false, inlineSourceMap: enableSourceMap, inlineSources: enableSourceMap},
+        {
+            noEmitOnError: false,
+            inlineSourceMap: enableSourceMap,
+            inlineSources: enableSourceMap,
+            ...(enableSourceMap ? {sourceMap: undefined} : {}),
+        },
         ts.sys,
         createProgram,
         reportDiagnostic,


### PR DESCRIPTION
Prevents simultaneous enabling `sourceMap` and `inlineSourcemap`