### PR TITLE
feat(Client): add setting to watch changes in node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ With this `{rootDir}/src/ui/tsconfig.json`:
   - `type` (`'https'`) — allow to serve over HTTPS.
   - `options` (`import('https').ServerOptions`) — allow to provide your own certificate.
 - `watchOptions` — a set of options used to customize watch mode, [more](https://webpack.js.org/configuration/watch/#watchoptions)
+  - `watchPackages` (`boolean`) - watch all changes in `node_modules`.
 - `disableReactRefresh` (`boolean`) — disable `react-refresh` in dev mode.
 - `detectCircularDependencies` (`true | CircularDependenciesOptions`) - detect modules with circular dependencies, [more](https://github.com/aackerman/circular-dependency-plugin)
 

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -145,9 +145,16 @@ export interface ClientConfig {
     polyfill?: {
         process?: boolean;
     };
-    // Add additional options to DefinePlugin
+    /**
+     * Add additional options to DefinePlugin
+     */
     definitions?: DefinePlugin['definitions'];
-    watchOptions?: Configuration['watchOptions'];
+    watchOptions?: Configuration['watchOptions'] & {
+        /**
+         * watch changes in node_modules
+         */
+        watchPackages?: boolean;
+    };
     cdn?: CdnUploadConfig | CdnUploadConfig[];
     /**
      * use webpack 5 Web Workers [syntax](https://webpack.js.org/guides/web-workers/#syntax)

--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -79,7 +79,7 @@ export function webpackConfigFactory(
         optimization: configureOptimization(helperOptions),
         externals: config.externals,
         node: config.node,
-        watchOptions: config.watchOptions,
+        watchOptions: configureWatchOptions(helperOptions),
         ignoreWarnings: [/Failed to parse source map/],
         infrastructureLogging: config.verbose
             ? {
@@ -99,6 +99,9 @@ export function webpackConfigFactory(
                       : undefined,
               }
             : undefined,
+        snapshot: {
+            managedPaths: config.watchOptions?.watchPackages ? [] : undefined,
+        },
     };
 }
 
@@ -178,6 +181,21 @@ function configureDevTool({isEnvProduction, config}: HelperOptions) {
     return config.disableSourceMapGeneration ? false : format;
 }
 
+function configureWatchOptions({config}: HelperOptions): webpack.Configuration['watchOptions'] {
+    const watchOptions = {
+        ...config.watchOptions,
+        followSymlinks:
+            config.watchOptions?.followSymlinks ??
+            (!config.symlinks && config.watchOptions?.watchPackages)
+                ? true
+                : undefined,
+    };
+
+    delete watchOptions.watchPackages;
+
+    return watchOptions;
+}
+
 export function configureResolve({
     isEnvProduction,
     config,
@@ -210,7 +228,7 @@ export function configureResolve({
         },
         modules: ['node_modules', ...modules, ...(config.modules || [])],
         extensions: ['.mjs', '.cjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
-        symlinks: config.symlinks || false,
+        symlinks: config.symlinks,
         fallback: config.fallback,
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
     configureWebpackConfigForStorybook,
     configureServiceWebpackConfig,
 } from './common/webpack/storybook';
+export * from './common/s3-upload';
 export {createTransformPathsToLocalModules} from './common/typescript/transformers';
 export {defineConfig} from './common/models';
 export type {ProjectConfig, ServiceConfig, LibraryConfig, ProjectFileConfig} from './common/models';


### PR DESCRIPTION
BREAKING CHANGE: change default value for setting `client.symlinks`, used default (true) from webpack.