### PR TITLE
feat(storybook): storybook 7 support

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -36,7 +36,7 @@ function omitUndefined<T extends object>(obj: T) {
 
 export async function getProjectConfig(
     command: string,
-    {env, storybook7, ...argv}: Partial<CliArgs & {storybook7: boolean}>,
+    {env, storybook7Mode, ...argv}: Partial<CliArgs & {storybook7Mode: boolean}>,
 ) {
     function getLoader(loader: Loader): Loader {
         return async (pathname: string, content: string) => {
@@ -49,7 +49,7 @@ export async function getProjectConfig(
     }
 
     // eslint-disable-next-line security/detect-non-literal-require
-    const loader = storybook7 ? (pathname: string) => require(pathname).default : getTsLoader();
+    const loader = storybook7Mode ? (pathname: string) => require(pathname).default : getTsLoader();
     const tsLoader = getLoader(loader);
 
     const moduleName = 'app-builder';

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -34,7 +34,10 @@ function omitUndefined<T extends object>(obj: T) {
     return _.omitBy(obj, _.isUndefined);
 }
 
-export async function getProjectConfig(command: string, {env, ...argv}: Partial<CliArgs>) {
+export async function getProjectConfig(
+    command: string,
+    {env, storybook7, ...argv}: Partial<CliArgs & {storybook7: boolean}>,
+) {
     function getLoader(loader: Loader): Loader {
         return async (pathname: string, content: string) => {
             const config = loader(pathname, content);
@@ -45,7 +48,9 @@ export async function getProjectConfig(command: string, {env, ...argv}: Partial<
         };
     }
 
-    const tsLoader = getLoader(getTsLoader());
+    // eslint-disable-next-line security/detect-non-literal-require
+    const loader = storybook7 ? (pathname: string) => require(pathname).default : getTsLoader();
+    const tsLoader = getLoader(loader);
 
     const moduleName = 'app-builder';
     const explorer = cosmiconfigSync(moduleName, {

--- a/src/common/webpack/storybook.ts
+++ b/src/common/webpack/storybook.ts
@@ -16,8 +16,11 @@ type Mode = `${WebpackMode}`;
 export async function configureServiceWebpackConfig(
     mode: Mode,
     storybookConfig: Webpack.Configuration,
+    storybook7Mode = false,
 ): Promise<Webpack.Configuration> {
-    const serviceConfig = await getProjectConfig(mode === WebpackMode.Prod ? 'build' : 'dev', {});
+    const serviceConfig = await getProjectConfig(mode === WebpackMode.Prod ? 'build' : 'dev', {
+        storybook7: storybook7Mode,
+    });
     let options: ClientConfig = {};
     if (isLibraryConfig(serviceConfig)) {
         options = {

--- a/src/common/webpack/storybook.ts
+++ b/src/common/webpack/storybook.ts
@@ -19,7 +19,7 @@ export async function configureServiceWebpackConfig(
     storybook7Mode = false,
 ): Promise<Webpack.Configuration> {
     const serviceConfig = await getProjectConfig(mode === WebpackMode.Prod ? 'build' : 'dev', {
-        storybook7: storybook7Mode,
+        storybook7Mode,
     });
     let options: ClientConfig = {};
     if (isLibraryConfig(serviceConfig)) {


### PR DESCRIPTION
Storybook automatically [configures](https://github.com/storybookjs/storybook/blob/243ca403fc22495af179ebc5b135d6398e5c1ff2/code/lib/core-common/src/utils/interpret-require.ts#L13) the import of files with esbuild, so using cosmiconfig-typescript-loader leads to an error. This pull request adds the ability to disable cosmiconfig-typescript-loader for this case.