### PR TITLE
feat: statoscope can be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ With this `{rootDir}/src/ui/tsconfig.json`:
   - `true` — enable [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) plugin. Report generated to `dist/public/build/stats.html`
   - `statoscope` — enable [statoscope](https://github.com/statoscope/statoscope) plugin. Reports generated to `dist/public/build/stats.json` and `dist/public/build/report.json`
 - `reactProfiling` (`boolean`) — use react profiler API in production, this option also disable minimization. The API is required by React developers tools for profile.
+- `statoscopeConfig` (`Options`) — `@statoscope/webpack-plugin` [configuration options](https://github.com/statoscope/statoscope/tree/master/packages/webpack-plugin#usage). Might be used to override the defaults. Requires `analyzeBundle: statoscope`.
 - `cdn` (`CdnUploadConfig | CdnUploadConfig[]`) - upload bundled client files to CDN.
   - `bucket` (`string`) — bucket name
   - `prefix` (`string`) — path to files inside the bucket

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -7,6 +7,7 @@ import type {ServerConfiguration} from 'webpack-dev-server';
 import type {Options as CircularDependenciesOptions} from 'circular-dependency-plugin';
 import type {Config as SvgrConfig} from '@svgr/core';
 import type {ForkTsCheckerWebpackPluginOptions} from 'fork-ts-checker-webpack-plugin/lib/plugin-options';
+import type {Options as StatoscopeOptions} from '@statoscope/webpack-plugin';
 
 export interface Entities<T> {
     data: Record<string, T>;
@@ -132,6 +133,7 @@ export interface ClientConfig {
     entryFilter?: string[];
     excludeFromClean?: string[];
     analyzeBundle?: 'true' | 'statoscope';
+    statoscopeConfig?: StatoscopeOptions;
     reactProfiling?: boolean;
     /**
      *  Disable react-refresh in dev mode

--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -767,6 +767,8 @@ function configurePlugins(options: HelperOptions): webpack.Configuration['plugin
         }
 
         if (config.analyzeBundle === 'statoscope') {
+            const customStatoscopeConfig = config.statoscopeConfig || {};
+
             plugins.push(
                 new StatoscopeWebpackPlugin({
                     saveReportTo: path.resolve(paths.appBuild, 'report.html'),
@@ -775,6 +777,7 @@ function configurePlugins(options: HelperOptions): webpack.Configuration['plugin
                     statsOptions: {
                         all: true,
                     },
+                    ...customStatoscopeConfig,
                 }),
             );
         }


### PR DESCRIPTION
#### Why might you want to configure statoscope?
Firstly, to change the `statsOptions` that are being collected. The more you collect — the bigger the stats.json becomes.
Also, you might want to use it to disable the creation of html reports — those also spend substantial amount of cpu time, especially if you use report compression, and those might not be needed for you in case you have `statoscope compare`-based CI pipeline
Also, you might be using brotli instead of gzip — that is also overridable thorough config