### PR TITLE
fix(css): disable sass loaders for pure css

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -407,41 +407,11 @@ function createSassStylesRule({
     isEnvProduction,
     config,
 }: HelperOptions): webpack.RuleSetRule {
-    const loaders: webpack.RuleSetUseItem[] = [];
-
-    if (isEnvProduction) {
-        loaders.push(MiniCSSExtractPlugin.loader);
-    }
-
-    if (isEnvDevelopment) {
-        loaders.push({
-            loader: require.resolve('style-loader'),
-        });
-    }
-
-    loaders.push({
-        loader: require.resolve('css-loader'),
-        options: {
-            esModule: false,
-            sourceMap: !config.disableSourceMapGeneration,
-            importLoaders: 2,
-        },
+    const loaders = getCssLoaders({
+        isEnvDevelopment,
+        isEnvProduction,
+        config,
     });
-
-    if (!config.transformCssWithLightningCss) {
-        loaders.push({
-            loader: require.resolve('postcss-loader'),
-            options: {
-                sourceMap: !config.disableSourceMapGeneration,
-                postcssOptions: {
-                    config: false,
-                    plugins: [
-                        [require.resolve('postcss-preset-env'), {enableClientSidePolyfills: false}],
-                    ],
-                },
-            },
-        });
-    }
 
     loaders.push({
         loader: require.resolve('resolve-url-loader'),
@@ -472,13 +442,26 @@ function createStylesRule({
     isEnvProduction,
     config,
 }: HelperOptions): webpack.RuleSetRule {
+    const loaders = getCssLoaders({
+        isEnvDevelopment,
+        isEnvProduction,
+        config,
+    });
+    return {
+        test: /\.css$/,
+        sideEffects: isEnvProduction ? true : undefined,
+        use: loaders,
+    };
+}
+
+function getCssLoaders(opts: HelperOptions) {
     const loaders: webpack.RuleSetUseItem[] = [];
 
-    if (isEnvProduction) {
+    if (opts.isEnvProduction) {
         loaders.push(MiniCSSExtractPlugin.loader);
     }
 
-    if (isEnvDevelopment) {
+    if (opts.isEnvDevelopment) {
         loaders.push({
             loader: require.resolve('style-loader'),
         });
@@ -488,16 +471,16 @@ function createStylesRule({
         loader: require.resolve('css-loader'),
         options: {
             esModule: false,
-            sourceMap: !config.disableSourceMapGeneration,
+            sourceMap: !opts.config.disableSourceMapGeneration,
             importLoaders: 2,
         },
     });
 
-    if (!config.transformCssWithLightningCss) {
+    if (!opts.config.transformCssWithLightningCss) {
         loaders.push({
             loader: require.resolve('postcss-loader'),
             options: {
-                sourceMap: !config.disableSourceMapGeneration,
+                sourceMap: !opts.config.disableSourceMapGeneration,
                 postcssOptions: {
                     config: false,
                     plugins: [
@@ -507,12 +490,7 @@ function createStylesRule({
             },
         });
     }
-
-    return {
-        test: /\.css$/,
-        sideEffects: isEnvProduction ? true : undefined,
-        use: loaders,
-    };
+    return loaders;
 }
 
 function createIconsRule(

--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -454,14 +454,14 @@ function createStylesRule({
     };
 }
 
-function getCssLoaders(opts: HelperOptions) {
+function getCssLoaders({isEnvDevelopment, isEnvProduction, config}: HelperOptions) {
     const loaders: webpack.RuleSetUseItem[] = [];
 
-    if (opts.isEnvProduction) {
+    if (isEnvProduction) {
         loaders.push(MiniCSSExtractPlugin.loader);
     }
 
-    if (opts.isEnvDevelopment) {
+    if (isEnvDevelopment) {
         loaders.push({
             loader: require.resolve('style-loader'),
         });
@@ -471,16 +471,16 @@ function getCssLoaders(opts: HelperOptions) {
         loader: require.resolve('css-loader'),
         options: {
             esModule: false,
-            sourceMap: !opts.config.disableSourceMapGeneration,
+            sourceMap: !config.disableSourceMapGeneration,
             importLoaders: 2,
         },
     });
 
-    if (!opts.config.transformCssWithLightningCss) {
+    if (!config.transformCssWithLightningCss) {
         loaders.push({
             loader: require.resolve('postcss-loader'),
             options: {
-                sourceMap: !opts.config.disableSourceMapGeneration,
+                sourceMap: !config.disableSourceMapGeneration,
                 postcssOptions: {
                     config: false,
                     plugins: [


### PR DESCRIPTION
We have to separate these two flows. We do useless work for css and generate annoying warnings.

Example:

```
WARNING in ./node_modules/@doc-tools/transform/dist/css/yfm.css (./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[2].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[2].use[2]!./node_modules/resolve-url-loader/index.js??ruleSet[1].rules[1].oneOf[2].use[3]!./node_modules/@doc-tools/transform/dist/css/yfm.css)
Module Warning (from ./node_modules/resolve-url-loader/index.js):
resolve-url-loader: webpack misconfiguration
  webpack or the upstream loader did not supply a source-map
```