### PR TITLE
fix: fixed handling `"` in replacing scss with css imports

### DIFF
--- a/src/common/library/index.ts
+++ b/src/common/library/index.ts
@@ -240,6 +240,7 @@ export function buildLibrary(config: LibraryConfig) {
                     let code =
                         transformed.code
                             ?.replace(/import '\.(.*)\.scss';/g, "import '.$1.css';")
+                            ?.replace(/import "\.(.*)\.scss";/g, 'import ".$1.css";')
                             ?.replace(
                                 /import (\w*) from '\.\.\/(.*)\/assets\/(.*)\.svg';/g,
                                 "import $1 from '$2/assets/$3';",

--- a/src/common/library/index.ts
+++ b/src/common/library/index.ts
@@ -240,7 +240,6 @@ export function buildLibrary(config: LibraryConfig) {
                     let code =
                         transformed.code
                             ?.replace(/import ['"]\.(.*)\.scss['"];/g, "import '.$1.css';")
-                            ?.replace(/import "\.(.*)\.scss";/g, 'import ".$1.css";')
                             ?.replace(
                                 /import (\w*) from '\.\.\/(.*)\/assets\/(.*)\.svg';/g,
                                 "import $1 from '$2/assets/$3';",

--- a/src/common/library/index.ts
+++ b/src/common/library/index.ts
@@ -239,7 +239,7 @@ export function buildLibrary(config: LibraryConfig) {
                 } else if (transformed) {
                     let code =
                         transformed.code
-                            ?.replace(/import '\.(.*)\.scss';/g, "import '.$1.css';")
+                            ?.replace(/import ['"]\.(.*)\.scss['"];/g, "import '.$1.css';")
                             ?.replace(/import "\.(.*)\.scss";/g, 'import ".$1.css";')
                             ?.replace(
                                 /import (\w*) from '\.\.\/(.*)\/assets\/(.*)\.svg';/g,


### PR DESCRIPTION
If a project uses `"` insteand of `'`, then the replacing wouldn't work
I fixed that in this PR