### PR TITLE
fix: add @babel/plugin-transform-class-properties to workaround bug in Safari 15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/core": "^7.22.0",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-proposal-decorators": "^7.22.0",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
         "@babel/plugin-transform-dynamic-import": "^7.22.0",
         "@babel/plugin-transform-modules-commonjs": "^7.22.0",
         "@babel/plugin-transform-runtime": "^7.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@aws-sdk/client-s3": "^3.353.0",
         "@babel/core": "^7.22.0",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-decorators": "^7.22.0",
         "@babel/plugin-transform-dynamic-import": "^7.22.0",
         "@babel/plugin-transform-modules-commonjs": "^7.22.0",
@@ -2048,22 +2047,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.13.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
-      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.353.0",
         "@babel/core": "^7.22.0",
         "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-decorators": "^7.22.0",
         "@babel/plugin-transform-dynamic-import": "^7.22.0",
         "@babel/plugin-transform-modules-commonjs": "^7.22.0",
@@ -2047,6 +2048,22 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-class-properties": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@aws-sdk/client-s3": "^3.353.0",
     "@babel/core": "^7.22.0",
     "@babel/helper-plugin-utils": "^7.22.5",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.0",
     "@babel/plugin-transform-dynamic-import": "^7.22.0",
     "@babel/plugin-transform-modules-commonjs": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@babel/core": "^7.22.0",
     "@babel/helper-plugin-utils": "^7.22.5",
     "@babel/plugin-proposal-decorators": "^7.22.0",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/plugin-transform-dynamic-import": "^7.22.0",
     "@babel/plugin-transform-modules-commonjs": "^7.22.0",
     "@babel/plugin-transform-runtime": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@aws-sdk/client-s3": "^3.353.0",
     "@babel/core": "^7.22.0",
     "@babel/helper-plugin-utils": "^7.22.5",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.0",
     "@babel/plugin-transform-dynamic-import": "^7.22.0",
     "@babel/plugin-transform-modules-commonjs": "^7.22.0",

--- a/src/common/babel/ui-preset.ts
+++ b/src/common/babel/ui-preset.ts
@@ -49,6 +49,13 @@ module.exports = function (_context: unknown, options: Record<string, any> = {})
     const plugins = [
         // Polyfills the runtime needed for async/await and generators
         [require.resolve('@babel/plugin-transform-runtime'), runtimeOptions],
+        /**
+         * Safari 15 has a buggy implementation of class properties,
+         * but @babel/compat-data marks it as stable.
+         * Can be removed once the issue is fixed and released.
+         * @see https://github.com/babel/babel/issues/14289
+         */
+        [require.resolve('@babel/plugin-proposal-class-properties')],
         isEnvProduction && [
             require.resolve('babel-plugin-transform-react-remove-prop-types'),
             {

--- a/src/common/babel/ui-preset.ts
+++ b/src/common/babel/ui-preset.ts
@@ -55,7 +55,7 @@ module.exports = function (_context: unknown, options: Record<string, any> = {})
          * Can be removed once the issue is fixed and released.
          * @see https://github.com/babel/babel/issues/14289
          */
-        [require.resolve('@babel/plugin-proposal-class-properties')],
+        [require.resolve('@babel/plugin-transform-class-properties')],
         isEnvProduction && [
             require.resolve('babel-plugin-transform-react-remove-prop-types'),
             {


### PR DESCRIPTION
Safari 15 has a bug in class fields implementation.
see babel/babel#14289

Workaround: add @babel/plugin-proposal-class-properties to plugins.