### PR TITLE
fix: move transform-class-properties to presets

### DIFF
--- a/src/common/babel/ui-preset.ts
+++ b/src/common/babel/ui-preset.ts
@@ -18,6 +18,17 @@ module.exports = function (_context: unknown, options: Record<string, any> = {})
     const reactOptions = getOption(options.react, {});
 
     const presets = [
+        [
+            () => ({
+                /**
+                 * Safari 15 has a buggy implementation of class properties,
+                 * but @babel/compat-data marks it as stable.
+                 * Can be removed once the issue is fixed and released.
+                 * @see https://github.com/babel/babel/issues/14289
+                 */
+                plugins: [require.resolve('@babel/plugin-transform-class-properties')],
+            }),
+        ],
         // Latest stable ECMAScript features
         (isEnvDevelopment || isEnvProduction) && [require.resolve('@babel/preset-env'), envOptions],
         // ES features necessary for current Node version
@@ -49,13 +60,6 @@ module.exports = function (_context: unknown, options: Record<string, any> = {})
     const plugins = [
         // Polyfills the runtime needed for async/await and generators
         [require.resolve('@babel/plugin-transform-runtime'), runtimeOptions],
-        /**
-         * Safari 15 has a buggy implementation of class properties,
-         * but @babel/compat-data marks it as stable.
-         * Can be removed once the issue is fixed and released.
-         * @see https://github.com/babel/babel/issues/14289
-         */
-        [require.resolve('@babel/plugin-transform-class-properties')],
         isEnvProduction && [
             require.resolve('babel-plugin-transform-react-remove-prop-types'),
             {


### PR DESCRIPTION
Because we need to run transform after `@babel/preset-typescript`

> SyntaxError: TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript.
> If you have already enabled that plugin (or '@babel/preset-typescript'), make sure that it runs before any plugin related to additional class features:
> - @babel/plugin-transform-class-properties
> - @babel/plugin-transform-private-methods
> - @babel/plugin-proposal-decorators 

Plugin ordering:

```
Plugins run before Presets.
Plugin ordering is first to last.
Preset ordering is reversed (last to first).
```

https://babeljs.io/docs/plugins#plugin-ordering