### PR TITLE
fix: redundant JS chunks for each CSS chunk

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -926,7 +926,7 @@ function configureOptimization({config}: HelperOptions): webpack.Configuration['
                       }
                     : undefined),
                 css: {
-                    test: /\.css$/,
+                    type: 'css/mini-extract',
                     enforce: true,
                     minChunks: 2,
                     reuseExistingChunk: true,


### PR DESCRIPTION
Using `test` cause bundling of redundant "empty" JS chunks for each generated CSS chunk. With using `type` instead this was fixed.