### PR TITLE
feat: remove lodash from vendors list

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -895,7 +895,6 @@ function configureOptimization({config}: HelperOptions): webpack.Configuration['
         'redux',
         'react-redux',
         '@reduxjs/toolkit',
-        'lodash',
         'lodash-es',
         'moment',
         'bem-cn-lite',


### PR DESCRIPTION
App-builder uses `babel-plugin-import`  for lodash treeshaking. But it doesn't work correctly:

<img width="397" alt="image" src="https://github.com/gravity-ui/app-builder/assets/1742586/a0b6da59-54b9-447b-97d4-cf9b66e69c07">

The reason is `vendors` https://www.npmjs.com/package/babel-plugin-import#note

I removed `lodash` from `vendors` and my bundle was fixed

![telegram-cloud-photo-size-2-5316814314813904879-x](https://github.com/gravity-ui/app-builder/assets/1742586/ba909965-efcd-4a7d-8da1-c9bbf54d3e9d)
