### PR TITLE
fix(worker): fix public path in worker

### DIFF
--- a/src/common/webpack/worker/web-worker.mts
+++ b/src/common/webpack/worker/web-worker.mts
@@ -27,7 +27,7 @@ function generateWorkerLoader(url: string | URL) {
     const publicPath = __webpack_public_path__;
     const workerPublicPath = publicPath.match(/^https?:\/\//)
         ? publicPath
-        : new URL(publicPath, window.location.href).toString();
+        : new URL(publicPath, window.location.origin).toString();
     const objectURL = URL.createObjectURL(
         new Blob(
             [


### PR DESCRIPTION
The problem:
Worker doesn't work in storybook because __webpack_public_path__ is empty string and dynamic imports inside worker get wrong public path.