### PR TITLE
feat: make css-modules class names human-readable

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -489,6 +489,11 @@ function getCssLoaders({isEnvDevelopment, isEnvProduction, config}: HelperOption
             esModule: false,
             sourceMap: !config.disableSourceMapGeneration,
             importLoaders: 2,
+            modules: {
+                auto: true,
+                localIdentName: '[name]__[local]--[hash:base64:5]',
+                exportLocalsConvention: 'camelCase',
+            },
         },
     });
 


### PR DESCRIPTION
Minor improvement to css modules support.
This pull request makes generated css-modules class names human readable (instead of something like `kImIF7sZoAjSPn74Hpe8`).

Without this improvement css-modules are nearly unusable and are completely undebuggable.

===============
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.