### PR TITLE
docs: add comment about build time to monaco languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ With this `{rootDir}/src/ui/tsconfig.json`:
 
 - `monaco` (`object`) — use [monaco-editor-webpack-plugin](https://github.com/microsoft/monaco-editor/tree/main/webpack-plugin#monaco-editor-webpack-loader-plugin)
 
-  - `fileName` (`string`) — custom filename template for worker scripts
-  - `languages` (`string[]`) - include only a subset of the languages supported.
+  - `fileName` (`string`) — custom filename template for worker scripts.
+  - `languages` (`string[]`) - include only a subset of the languages supported. If you don't need support for all languages, set needed languages explicitly, since it may significantly affect build time.
   - `features` (`string[]`) - include only a subset of the editor features.
   - `customLanguages` (`IFeatureDefinition[]`) - include custom languages (outside of the ones shipped with the `monaco-editor`).
 


### PR DESCRIPTION
Deleted `languages` field from my `monaco` config, build time increased from 2 minutes to 1.5 hour, no warning or error was shown. Probably, it will be worth mentioning in the docs, that it's better to use explicit languages set

![Screenshot 2024-08-06 at 13 40 14](https://github.com/user-attachments/assets/a8602875-d94f-4200-940c-d9694356b8f1)
