### PR TITLE
fix(webpack): set correct `importLoaders` to `css-loader` options

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -2,7 +2,6 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as webpack from 'webpack';
-import _ from 'lodash';
 import {CleanWebpackPlugin} from 'clean-webpack-plugin';
 import {WebpackManifestPlugin} from 'webpack-manifest-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
@@ -25,7 +24,7 @@ import {babelPreset} from '../babel';
 import type {NormalizedClientConfig} from '../models';
 import type {Logger} from '../logger';
 import {ProgressPlugin} from './progress-plugin';
-import {resolveTsconfigPathsToAlias} from './utils';
+import {resolveTsconfigPathsToAlias, setImportLoaders} from './utils';
 import {S3UploadPlugin} from '../s3-upload';
 import {logConfig} from '../logger/log-config';
 import {resolveTypescript} from '../typescript/utils';
@@ -386,6 +385,8 @@ function createSassStylesRule(options: HelperOptions): webpack.RuleSetRule {
         },
     });
 
+    setImportLoaders(loaders);
+
     return {
         test: /\.scss$/,
         sideEffects: options.isEnvProduction ? true : undefined,
@@ -395,6 +396,9 @@ function createSassStylesRule(options: HelperOptions): webpack.RuleSetRule {
 
 function createStylesRule(options: HelperOptions): webpack.RuleSetRule {
     const loaders = getCssLoaders(options);
+
+    setImportLoaders(loaders);
+
     return {
         test: /\.css$/,
         sideEffects: options.isEnvProduction ? true : undefined,

--- a/src/common/webpack/utils.test.ts
+++ b/src/common/webpack/utils.test.ts
@@ -1,0 +1,24 @@
+import type webpack from 'webpack';
+import {setImportLoaders} from './utils';
+
+describe('setImportLoaders', () => {
+    test('should set correct `importLoaders` to `css-loader` rule', () => {
+        const cssLoader = {
+            loader: 'foo/css-loader/bar.js',
+            options: {
+                importLoaders: 2,
+            },
+        };
+        const loaders: webpack.RuleSetUseItem[] = [
+            'style-loader',
+            cssLoader,
+            'postcss-loader',
+            'resolve-url-loader',
+            'sass-loader',
+        ];
+
+        setImportLoaders(loaders);
+
+        expect(cssLoader.options.importLoaders).toBe(3);
+    });
+});

--- a/src/common/webpack/utils.ts
+++ b/src/common/webpack/utils.ts
@@ -89,3 +89,31 @@ function readJsonConfig(pathname: string) {
         throw new Error(`Couldn't read config ${pathname}`);
     }
 }
+
+function isCssLoader(
+    rule: webpack.RuleSetUseItem,
+): rule is Exclude<webpack.RuleSetUseItem, string | Function> {
+    return Boolean(
+        typeof rule !== 'string' && 'loader' in rule && rule.loader?.includes('/css-loader/'),
+    );
+}
+
+/**
+ * Set correct `importLoaders` value, based on total loaders array
+ */
+export function setImportLoaders(loaders: webpack.RuleSetUseItem[]) {
+    const cssLoaderIndex = loaders.findIndex(isCssLoader);
+
+    if (cssLoaderIndex === -1) {
+        return;
+    }
+
+    const cssLoader = loaders[cssLoaderIndex];
+    const importLoaders = loaders.length - (cssLoaderIndex + 1);
+
+    if (cssLoader && isCssLoader(cssLoader)) {
+        if (cssLoader.options && typeof cssLoader.options !== 'string') {
+            cssLoader.options.importLoaders = importLoaders;
+        }
+    }
+}


### PR DESCRIPTION
`css-loader` option importsLoader for SASS files should be 3, because there is a 3 loaders before: `postcss-loader`, `resolve-url-loader` and `sass-loader`.

This also fix warnings from `resolve-url-loader` about webpack misconfiguration.