### PR TITLE
feat: add lightningCssMinimizerOptions in config and exclude langSelectorList in lightningcss

### DIFF
--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -4,6 +4,7 @@ import type {IFeatureDefinition} from 'monaco-editor-webpack-plugin/out/types';
 import type {Options as MomentTzOptions} from 'moment-timezone-data-webpack-plugin';
 import type {Configuration, DefinePlugin, FileCacheOptions, MemoryCacheOptions} from 'webpack';
 import type {
+    LightningCssMinimizerRspackPluginOptions,
     Configuration as RspackConfiguration,
     SwcJsMinimizerRspackPluginOptions,
 } from '@rspack/core';
@@ -251,6 +252,11 @@ export interface ClientConfig {
     swcMinimizerOptions?: (
         options: SwcJsMinimizerRspackPluginOptions,
     ) => SwcJsMinimizerRspackPluginOptions;
+
+    /** Modify or return a custom [LightningCssMinimizerRspackPlugin](https://rspack.dev/plugins/rspack/lightning-css-minimizer-rspack-plugin) */
+    lightningCssMinimizerOptions?: (
+        options: LightningCssMinimizerRspackPluginOptions,
+    ) => LightningCssMinimizerRspackPluginOptions;
 
     ssr?: {
         noExternal?: string | RegExp | (string | RegExp)[] | true;

--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -1428,7 +1428,21 @@ function configureRspackOptimization(
     let cssMinimizer: Rspack.Plugin;
 
     if (config.transformCssWithLightningCss) {
-        cssMinimizer = new rspack.LightningCssMinimizerRspackPlugin();
+        let lightningCssMinifyOptions: Rspack.LightningCssMinimizerRspackPluginOptions = {
+            minimizerOptions: {
+                exclude: {
+                    langSelectorList: true,
+                },
+            },
+        };
+
+        const {lightningCssMinimizerOptions} = config;
+
+        if (typeof lightningCssMinimizerOptions === 'function') {
+            lightningCssMinifyOptions = lightningCssMinimizerOptions(lightningCssMinifyOptions);
+        }
+
+        cssMinimizer = new rspack.LightningCssMinimizerRspackPlugin(lightningCssMinifyOptions);
     } else {
         const CssMinimizerPlugin: typeof CssMinimizerWebpackPlugin = require('css-minimizer-webpack-plugin');
         cssMinimizer = new CssMinimizerPlugin({


### PR DESCRIPTION
Lightning CSS generates additional superfluous styles
To remove styles with a pseudo-class :lang the Lang Selector List option has been excluded

To customize the Lightning CSS parameters, the lightningCssMinimizerOptions option was added to the config