### PR TITLE
fix: exclude logicalProperties-in-lightningcss

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -1432,6 +1432,7 @@ function configureRspackOptimization(
             minimizerOptions: {
                 exclude: {
                     langSelectorList: true,
+                    logicalProperties: true,
                 },
             },
         };


### PR DESCRIPTION
Remove the conversion of logical properties to physical css in lightningcss