### PR TITLE
fix: avoid FOUC and deduplication optimization in style-loader insert (dev)

### DIFF
--- a/src/common/webpack/insert-style-tag.js
+++ b/src/common/webpack/insert-style-tag.js
@@ -1,29 +1,36 @@
 /* eslint-env browser */
 
+const ATTR = 'data-ab-styleid';
+
+function hash(str) {
+    let h = 0;
+    for (let i = 0; i < str.length; i++) {
+        h = (h * 31 + str.charCodeAt(i)) % 4294967291;
+    }
+    return h.toString(36);
+}
+
 /**
- * This function inserts a style tag into the document head if it doesn't already exist.
- * It is needed to do not allow duplicate style tags.
+ * Inserts a style tag into <head> unless an identical one is already present.
+ * Dedup is keyed by a content hash stored on the tag,
+ * and reflects DOM removals (HMR) automatically.
  *
  * @param {HTMLStyleElement} $targetStyle - The style element to be inserted
  * @returns {void}
  */
 function insertStyleTag($targetStyle) {
-    // setTimeout is used to queue the insertion of the style tag
-    // to the end of the current event loop, allowing other
-    setTimeout(() => {
-        const $head = document.head;
-
-        let targetStyleExists = false;
-
-        $head.querySelectorAll('style').forEach(($style) => {
-            if ($style.innerHTML === $targetStyle.innerHTML) {
-                targetStyleExists = true;
-            }
-        });
-
-        if (!targetStyleExists) {
-            $head.appendChild($targetStyle);
+    // style-loader passes an empty <style> and fills its content right after this
+    // call returns, so the content is not available synchronously.
+    queueMicrotask(() => {
+        const html = $targetStyle.innerHTML;
+        const id = hash(html);
+        const $existing = document.head.querySelector(`style[${ATTR}="${id}"]`);
+        // innerHTML check guards against the rare hash collision
+        if ($existing && $existing.innerHTML === html) {
+            return;
         }
+        $targetStyle.setAttribute(ATTR, id);
+        document.head.appendChild($targetStyle);
     });
 }
 


### PR DESCRIPTION
## Problem

The custom `insert` for `style-loader` (dev only) deduped `<style>` tags by comparing `innerHTML` against every existing tag on each insertion — O(n²) over tag count. With ~500 style files this is ~128k full-string comparisons.

It also deferred insertion via `setTimeout` (a macrotask), so the browser could paint the unstyled DOM before styles applied. This produced a visible flash of unstyled content (FOUC) in Firefox; Chrome happened not to show it.

## Fix

- Defer with `queueMicrotask` instead of `setTimeout`. Microtasks drain at the end of the current task, before the browser paints, so styles apply without a flash. The deferral is still required because `style-loader` passes an empty `<style>` element and fills its content only after `insert` returns.
- Replace the O(n²) `innerHTML` scan with an O(n) lookup: store a content hash in a `data-ab-styleid` attribute and find duplicates via `querySelector`. The attribute lives on the tag, so it reflects DOM removals (HMR) automatically. A final `innerHTML` equality check guards against the rare hash collision, keeping dedup behavior identical.

Dev-only change; production uses `MiniCssExtractPlugin` and is unaffected.
