### PR TITLE
fix(dev): clean TypeScript incremental state with server output

### DIFF
--- a/src/commands/dev/server.ts
+++ b/src/commands/dev/server.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {rimraf} from 'rimraf';
 
 import {ControllableScript} from '../../common/child-process/controllable-script';
@@ -28,7 +29,8 @@ watch(
         onAfterFilesEmitted: () => {
             process.send({type: 'Emitted'});
         },
-        enableSourceMap: true
+        enableSourceMap: true,
+        tsBuildInfoFile: ${JSON.stringify(path.join(config.server.outputPath, '.tsbuildinfo'))}
     }
 );`;
 }

--- a/src/common/typescript/watch.test.ts
+++ b/src/common/typescript/watch.test.ts
@@ -1,0 +1,76 @@
+import type Typescript from 'typescript';
+
+import {watch} from './watch';
+
+describe('TypeScript watch', () => {
+    it('overrides tsBuildInfoFile only for the root project', () => {
+        const configPath = '/project/src/server/tsconfig.json';
+        const referencedConfigPath = '/project/packages/shared/tsconfig.json';
+        const tsBuildInfoFile = '/project/dist/server/.tsbuildinfo';
+        const getParsedCommandLineOfConfigFile = jest.fn(
+            (_fileName: string, _options?: Typescript.CompilerOptions) => ({
+                options: {},
+                fileNames: [],
+                errors: [],
+            }),
+        );
+        const host = {
+            readFile: jest.fn(),
+            createProgram: jest.fn(),
+        };
+        const build = jest.fn();
+        const ts = {
+            version: '5.6.3',
+            sys: {
+                newLine: '\n',
+                useCaseSensitiveFileNames: true,
+                getCurrentDirectory: () => '/project',
+                readDirectory: jest.fn(),
+                fileExists: jest.fn(),
+                readFile: jest.fn(),
+            },
+            findConfigFile: jest.fn(
+                (searchPath: string, _fileExists: unknown, fileName = 'tsconfig.json') =>
+                    `${searchPath}/${fileName}`,
+            ),
+            getParsedCommandLineOfConfigFile,
+            createEmitAndSemanticDiagnosticsBuilderProgram: jest.fn(),
+            createSolutionBuilderWithWatchHost: jest.fn(() => host),
+            createSolutionBuilderWithWatch: jest.fn((solutionHost) => {
+                solutionHost.getParsedCommandLine(configPath);
+                solutionHost.getParsedCommandLine(referencedConfigPath);
+                return {build};
+            }),
+        } as unknown as typeof Typescript;
+        const logger = {
+            message: jest.fn(),
+            verbose: jest.fn(),
+            status: jest.fn(),
+            clearLine: jest.fn(),
+            colors: {dim: (value: string) => value},
+            isVerbose: false,
+        };
+
+        watch(ts, '/project/src/server', {
+            logger: logger as never,
+            tsBuildInfoFile,
+        });
+
+        expect(getParsedCommandLineOfConfigFile).toHaveBeenNthCalledWith(
+            1,
+            configPath,
+            expect.objectContaining({tsBuildInfoFile, noEmit: false}),
+            expect.any(Object),
+        );
+        expect(getParsedCommandLineOfConfigFile).toHaveBeenNthCalledWith(
+            2,
+            referencedConfigPath,
+            expect.objectContaining({noEmit: false}),
+            expect.any(Object),
+        );
+        expect(getParsedCommandLineOfConfigFile.mock.calls[1]?.[1]).not.toHaveProperty(
+            'tsBuildInfoFile',
+        );
+        expect(build).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/common/typescript/watch.ts
+++ b/src/common/typescript/watch.ts
@@ -1,7 +1,8 @@
+import nodePath from 'node:path';
 import type Typescript from 'typescript';
 import type {Logger} from '../logger';
 import {createTransformPathsToLocalModules} from './transformers';
-import {displayFilename, getTsProjectConfigPath, onHostEvent} from './utils';
+import {displayFilename, getTsProjectConfig, getTsProjectConfigPath, onHostEvent} from './utils';
 import {formatDiagnosticBrief} from './diagnostic';
 
 /** @see https://github.com/microsoft/TypeScript/blob/9059e5bda0bb603ae6b41eca09dcd2a071af45fd/src/compiler/diagnosticMessages.json#L5400-L5403 */
@@ -17,11 +18,24 @@ export function watch(
         logger,
         onAfterFilesEmitted,
         enableSourceMap,
-    }: {logger: Logger; onAfterFilesEmitted?: () => void; enableSourceMap?: boolean},
+        tsBuildInfoFile,
+    }: {
+        logger: Logger;
+        onAfterFilesEmitted?: () => void;
+        enableSourceMap?: boolean;
+        tsBuildInfoFile?: string;
+    },
 ) {
     logger.message('Start compilation in watch mode');
     logger.message(`Typescript v${ts.version}`);
     const configPath = getTsProjectConfigPath(ts, projectPath);
+    const optionsToExtend = {
+        noEmit: false,
+        noEmitOnError: false,
+        inlineSourceMap: enableSourceMap,
+        inlineSources: enableSourceMap,
+        ...(enableSourceMap ? {sourceMap: false} : undefined),
+    };
 
     const createProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram;
 
@@ -32,6 +46,18 @@ export function watch(
         reportDiagnostic,
         reportWatchStatusChanged,
     );
+
+    if (tsBuildInfoFile) {
+        host.getParsedCommandLine = (fileName) =>
+            getTsProjectConfig(
+                ts,
+                nodePath.dirname(fileName),
+                nodePath.basename(fileName),
+                nodePath.resolve(fileName) === nodePath.resolve(configPath)
+                    ? {...optionsToExtend, tsBuildInfoFile}
+                    : optionsToExtend,
+            );
+    }
 
     onHostEvent(
         host,
@@ -68,13 +94,7 @@ export function watch(
 
     // `createSolutionBuilderWithWatch` creates an initial program, watches files, and updates
     // the program over time.
-    const solutionBuilder = ts.createSolutionBuilderWithWatch(host, [configPath], {
-        noEmit: false,
-        noEmitOnError: false,
-        inlineSourceMap: enableSourceMap,
-        inlineSources: enableSourceMap,
-        ...(enableSourceMap ? {sourceMap: false} : undefined),
-    });
+    const solutionBuilder = ts.createSolutionBuilderWithWatch(host, [configPath], optionsToExtend);
 
     const transformPathsToLocalModules = createTransformPathsToLocalModules(ts);
 


### PR DESCRIPTION
Store tsBuildInfoFile in the dev server output directory so composite projects rebuild after cleanup.