### PR TITLE
fix(s3-upload): S3 upload fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,9 +10,6 @@ const config = {
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },
-    moduleNameMapper: {
-        '^(\\.{1,2}/.*)\\.js$': '$1',
-    },
     coverageDirectory: './coverage',
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],
     passWithNoTests: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,9 @@ const config = {
     moduleNameMapper: {
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },
+    moduleNameMapper: {
+        '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
     coverageDirectory: './coverage',
     collectCoverageFrom: ['src/**/*.{ts,tsx}'],
     passWithNoTests: true,

--- a/src/common/models/index.ts
+++ b/src/common/models/index.ts
@@ -476,6 +476,13 @@ export interface CdnUploadConfig {
     prefix?: string;
     region?: string;
     endpoint?: string;
+    /**
+     * Maximum number of S3 request attempts, including the initial request.
+     * @default 5
+     */
+    maxAttempts?: number;
+    /** @default 'adaptive' */
+    retryMode?: 'standard' | 'adaptive';
     publicPath?: string;
     compress?: boolean;
     cacheControl?: UploadOptions['cacheControl'];

--- a/src/common/s3-upload/create-plugin.test.ts
+++ b/src/common/s3-upload/create-plugin.test.ts
@@ -1,11 +1,16 @@
-import {createS3UploadPlugins} from './create-plugin';
-import {S3UploadPlugin} from './webpack-plugin';
+import {jest} from '@jest/globals';
 
-import type {NormalizedClientConfig} from '../models';
+import type {NormalizedClientConfig} from '../models/index.js';
+import type {S3UploadPlugin} from './webpack-plugin.js';
 
-jest.mock('./webpack-plugin');
+const mockedS3UploadPlugin =
+    jest.fn<(...args: ConstructorParameters<typeof S3UploadPlugin>) => S3UploadPlugin>();
 
-const mockedS3UploadPlugin = jest.mocked(S3UploadPlugin);
+jest.unstable_mockModule('./webpack-plugin.js', () => ({
+    S3UploadPlugin: mockedS3UploadPlugin,
+}));
+
+const {createS3UploadPlugins} = await import('./create-plugin.js');
 
 beforeEach(() => {
     jest.clearAllMocks();

--- a/src/common/s3-upload/create-plugin.test.ts
+++ b/src/common/s3-upload/create-plugin.test.ts
@@ -1,0 +1,48 @@
+import {createS3UploadPlugins} from './create-plugin';
+import {S3UploadPlugin} from './webpack-plugin';
+
+import type {NormalizedClientConfig} from '../models';
+
+jest.mock('./webpack-plugin');
+
+const mockedS3UploadPlugin = jest.mocked(S3UploadPlugin);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('createS3UploadPlugins', () => {
+    it.each([
+        [undefined, 5],
+        [8, 8],
+    ])('passes maxAttempts %s as %s to the S3 client', (configured, expected) => {
+        createS3UploadPlugins({
+            cdn: {
+                bucket: 'bucket',
+                maxAttempts: configured,
+            },
+        } as NormalizedClientConfig);
+
+        expect(mockedS3UploadPlugin).toHaveBeenCalledTimes(1);
+        expect(mockedS3UploadPlugin.mock.calls[0]?.[0].s3ClientOptions).toEqual(
+            expect.objectContaining({maxAttempts: expected}),
+        );
+    });
+
+    it.each([
+        [undefined, 'adaptive'],
+        ['standard', 'standard'],
+    ])('passes retryMode %s as %s to the S3 client', (configured, expected) => {
+        createS3UploadPlugins({
+            cdn: {
+                bucket: 'bucket',
+                retryMode: configured,
+            },
+        } as NormalizedClientConfig);
+
+        expect(mockedS3UploadPlugin).toHaveBeenCalledTimes(1);
+        expect(mockedS3UploadPlugin.mock.calls[0]?.[0].s3ClientOptions).toEqual(
+            expect.objectContaining({retryMode: expected}),
+        );
+    });
+});

--- a/src/common/s3-upload/create-plugin.ts
+++ b/src/common/s3-upload/create-plugin.ts
@@ -5,6 +5,9 @@ import type {Configuration} from 'webpack';
 import type {Logger} from '../logger/index.js';
 import {hasMFAssetsIsolation} from '../utils.js';
 
+const DEFAULT_S3_MAX_ATTEMPTS = 5;
+const DEFAULT_S3_RETRY_MODE = 'adaptive';
+
 export function createS3UploadPlugins(config: NormalizedClientConfig, logger?: Logger) {
     const plugins: Required<Configuration['plugins']> = [];
 
@@ -45,6 +48,8 @@ export function createS3UploadPlugins(config: NormalizedClientConfig, logger?: L
                     region: cdn.region,
                     endpoint: cdn.endpoint,
                     credentials,
+                    maxAttempts: cdn.maxAttempts ?? DEFAULT_S3_MAX_ATTEMPTS,
+                    retryMode: cdn.retryMode ?? DEFAULT_S3_RETRY_MODE,
                 },
                 s3UploadOptions: {
                     bucket: cdn.bucket,

--- a/src/common/s3-upload/upload.test.ts
+++ b/src/common/s3-upload/upload.test.ts
@@ -1,0 +1,71 @@
+import {getS3Client} from './s3-client';
+import {uploadFiles} from './upload';
+
+import type {Logger} from '../logger';
+
+jest.mock('./s3-client');
+jest.mock('p-queue', () => ({
+    __esModule: true,
+    default: class {
+        add<T>(task: () => T | PromiseLike<T>) {
+            return Promise.resolve().then(task);
+        }
+    },
+}));
+
+const mockedGetS3Client = jest.mocked(getS3Client);
+
+const headObject = jest.fn();
+const uploadFile = jest.fn();
+
+const logger = {
+    verbose: jest.fn(),
+    message: jest.fn(),
+    error: jest.fn(),
+} as unknown as Logger;
+
+function createConfig() {
+    return {
+        s3: {},
+        concurrency: 1,
+        options: {
+            bucket: 'bucket',
+            sourcePath: '/build',
+        },
+        logger,
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetS3Client.mockReturnValue({
+        headObject,
+        uploadFile,
+        uploadDir: jest.fn(),
+        deleteObject: jest.fn(),
+    } as unknown as ReturnType<typeof getS3Client>);
+    uploadFile.mockResolvedValue({});
+});
+
+describe('uploadFiles', () => {
+    it.each([{$metadata: {httpStatusCode: 404}}, {name: 'NotFound'}, {name: 'NoSuchKey'}])(
+        'uploads a file when HeadObject reports that it does not exist',
+        async (error) => {
+            headObject.mockRejectedValueOnce(error);
+
+            await expect(uploadFiles(['file.txt'], createConfig())).resolves.toEqual(['file.txt']);
+            expect(uploadFile).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it('propagates HeadObject errors other than not found', async () => {
+        const error = Object.assign(new Error('Forbidden'), {
+            name: 'AccessDenied',
+            $metadata: {httpStatusCode: 403},
+        });
+        headObject.mockRejectedValueOnce(error);
+
+        await expect(uploadFiles(['file.txt'], createConfig())).rejects.toBe(error);
+        expect(uploadFile).not.toHaveBeenCalled();
+    });
+});

--- a/src/common/s3-upload/upload.test.ts
+++ b/src/common/s3-upload/upload.test.ts
@@ -37,7 +37,7 @@ function createConfig() {
 }
 
 beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     mockedGetS3Client.mockReturnValue({
         headObject,
         uploadFile,
@@ -77,6 +77,22 @@ describe('uploadFiles', () => {
         expect(logger.message).toHaveBeenCalledWith(
             "Nothing to do with 'file.txt' because 'file.txt' already exists in 'bucket'",
         );
+    });
+
+    it('uploads without HeadObject when existsBehavior is overwrite', async () => {
+        headObject.mockRejectedValueOnce(new Error('HeadObject must not be called'));
+
+        await expect(
+            uploadFiles(['file.txt'], {
+                ...createConfig(),
+                options: {
+                    ...createConfig().options,
+                    existsBehavior: 'overwrite',
+                },
+            }),
+        ).resolves.toEqual(['file.txt']);
+        expect(headObject).not.toHaveBeenCalled();
+        expect(uploadFile).toHaveBeenCalledTimes(1);
     });
 
     it('builds an S3 key from the target prefix and a relative file path', async () => {

--- a/src/common/s3-upload/upload.test.ts
+++ b/src/common/s3-upload/upload.test.ts
@@ -99,4 +99,18 @@ describe('uploadFiles', () => {
             expect(uploadFile).not.toHaveBeenCalled();
         },
     );
+
+    it.each([
+        ['file.js.gz', 'gzip'],
+        ['file.js.br', 'br'],
+    ])('sets Content-Encoding when uploading %s', async (filePath, contentEncoding) => {
+        headObject.mockRejectedValueOnce({name: 'NotFound'});
+
+        await uploadFiles([filePath], createConfig());
+
+        expect(uploadFile).toHaveBeenCalledWith('bucket', `/build/${filePath}`, filePath, {
+            cacheControl: undefined,
+            contentEncoding,
+        });
+    });
 });

--- a/src/common/s3-upload/upload.test.ts
+++ b/src/common/s3-upload/upload.test.ts
@@ -68,4 +68,35 @@ describe('uploadFiles', () => {
         await expect(uploadFiles(['file.txt'], createConfig())).rejects.toBe(error);
         expect(uploadFile).not.toHaveBeenCalled();
     });
+
+    it('builds an S3 key from the target prefix and a relative file path', async () => {
+        headObject.mockRejectedValueOnce({name: 'NotFound'});
+
+        await uploadFiles(['/build/assets/file.txt'], {
+            ...createConfig(),
+            options: {
+                ...createConfig().options,
+                targetPath: 'releases/current',
+            },
+        });
+
+        expect(headObject).toHaveBeenCalledWith('bucket', 'releases/current/assets/file.txt');
+        expect(uploadFile).toHaveBeenCalledWith(
+            'bucket',
+            '/build/assets/file.txt',
+            'releases/current/assets/file.txt',
+            {cacheControl: undefined},
+        );
+    });
+
+    it.each(['../outside.txt', '/outside.txt'])(
+        'rejects a file outside of sourcePath: %s',
+        async (filePath) => {
+            await expect(uploadFiles([filePath], createConfig())).rejects.toThrow(
+                `File ${filePath} is outside of source path /build`,
+            );
+            expect(headObject).not.toHaveBeenCalled();
+            expect(uploadFile).not.toHaveBeenCalled();
+        },
+    );
 });

--- a/src/common/s3-upload/upload.test.ts
+++ b/src/common/s3-upload/upload.test.ts
@@ -1,11 +1,13 @@
-import {getS3Client} from './s3-client';
-import {uploadFiles} from './upload';
+import {jest} from '@jest/globals';
 
-import type {Logger} from '../logger';
+import type {Logger} from '../logger/index.js';
 
-jest.mock('./s3-client');
-jest.mock('p-queue', () => ({
-    __esModule: true,
+const mockedGetS3Client = jest.fn<typeof import('./s3-client.js').getS3Client>();
+
+jest.unstable_mockModule('./s3-client.js', () => ({
+    getS3Client: mockedGetS3Client,
+}));
+jest.unstable_mockModule('p-queue', () => ({
     default: class {
         add<T>(task: () => T | PromiseLike<T>) {
             return Promise.resolve().then(task);
@@ -13,10 +15,10 @@ jest.mock('p-queue', () => ({
     },
 }));
 
-const mockedGetS3Client = jest.mocked(getS3Client);
+const {uploadFiles} = await import('./upload.js');
 
-const headObject = jest.fn();
-const uploadFile = jest.fn();
+const headObject = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const uploadFile = jest.fn<(...args: unknown[]) => Promise<unknown>>();
 
 const logger = {
     verbose: jest.fn(),
@@ -43,7 +45,7 @@ beforeEach(() => {
         uploadFile,
         uploadDir: jest.fn(),
         deleteObject: jest.fn(),
-    } as unknown as ReturnType<typeof getS3Client>);
+    } as unknown as ReturnType<typeof import('./s3-client.js').getS3Client>);
     uploadFile.mockResolvedValue({});
 });
 

--- a/src/common/s3-upload/upload.test.ts
+++ b/src/common/s3-upload/upload.test.ts
@@ -69,6 +69,16 @@ describe('uploadFiles', () => {
         expect(uploadFile).not.toHaveBeenCalled();
     });
 
+    it('ignores an existing file by default', async () => {
+        headObject.mockResolvedValueOnce({});
+
+        await expect(uploadFiles(['file.txt'], createConfig())).resolves.toEqual(['file.txt']);
+        expect(uploadFile).not.toHaveBeenCalled();
+        expect(logger.message).toHaveBeenCalledWith(
+            "Nothing to do with 'file.txt' because 'file.txt' already exists in 'bucket'",
+        );
+    });
+
     it('builds an S3 key from the target prefix and a relative file path', async () => {
         headObject.mockRejectedValueOnce({name: 'NotFound'});
 

--- a/src/common/s3-upload/upload.ts
+++ b/src/common/s3-upload/upload.ts
@@ -37,9 +37,7 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
 
     return Promise.all(
         files.flatMap((filePath) => {
-            const relativeFilePath = path.isAbsolute(filePath)
-                ? path.relative(config.options.sourcePath, filePath)
-                : filePath;
+            const relativeFilePath = getRelativeFilePath(config.options.sourcePath, filePath);
             return processFile(relativeFilePath);
         }),
     );
@@ -70,8 +68,11 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
 
     function fileUploader(options: UploadOptions) {
         return async (relativeFilePath: string) => {
-            const sourceFilePath = path.join(options.sourcePath, relativeFilePath);
-            const targetFilePath = path.join(options.targetPath || '', relativeFilePath);
+            const sourceFilePath = path.resolve(options.sourcePath, relativeFilePath);
+            const targetFilePath = path.posix.join(
+                toPosixPath(options.targetPath ?? ''),
+                toPosixPath(relativeFilePath),
+            );
 
             log.verbose(`Uploading file ${relativeFilePath} ...`);
             const exists = await doesExist(options.bucket, targetFilePath);
@@ -154,6 +155,26 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
 }
 
 const NOT_COMPRESS = ['png', 'zip', 'gz', 'br'];
+
+function getRelativeFilePath(sourcePath: string, filePath: string) {
+    const absoluteSourcePath = path.resolve(sourcePath);
+    const absoluteFilePath = path.resolve(absoluteSourcePath, filePath);
+    const relativeFilePath = path.relative(absoluteSourcePath, absoluteFilePath);
+
+    if (
+        relativeFilePath === '..' ||
+        relativeFilePath.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(relativeFilePath)
+    ) {
+        throw new Error(`File ${filePath} is outside of source path ${sourcePath}`);
+    }
+
+    return relativeFilePath;
+}
+
+function toPosixPath(filePath: string) {
+    return filePath.split(path.sep).join(path.posix.sep);
+}
 
 function isNotFoundError(error: unknown) {
     if (!error || typeof error !== 'object') {

--- a/src/common/s3-upload/upload.ts
+++ b/src/common/s3-upload/upload.ts
@@ -11,6 +11,7 @@ export interface UploadOptions {
     bucket: string;
     sourcePath: string;
     targetPath?: string;
+    /** @default 'ignore' */
     existsBehavior?: 'overwrite' | 'throw' | 'ignore';
     cacheControl?: string | ((filename: string) => string);
 }
@@ -78,7 +79,9 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
             const exists = await doesExist(options.bucket, targetFilePath);
 
             if (exists) {
-                switch (options.existsBehavior) {
+                const existsBehavior = options.existsBehavior ?? 'ignore';
+
+                switch (existsBehavior) {
                     case 'overwrite': {
                         log.verbose(`File ${targetFilePath} will be overwritten.`);
                         break;
@@ -88,7 +91,7 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
                             `File ${targetFilePath} already exists in ${options.bucket}`,
                         );
                     }
-                    default: {
+                    case 'ignore': {
                         log.message(
                             `Nothing to do with '${relativeFilePath}' because '${targetFilePath}' already exists in '${options.bucket}'`,
                         );

--- a/src/common/s3-upload/upload.ts
+++ b/src/common/s3-upload/upload.ts
@@ -76,27 +76,22 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
             );
 
             log.verbose(`Uploading file ${relativeFilePath} ...`);
-            const exists = await doesExist(options.bucket, targetFilePath);
+            const existsBehavior = options.existsBehavior ?? 'ignore';
 
-            if (exists) {
-                const existsBehavior = options.existsBehavior ?? 'ignore';
+            if (existsBehavior !== 'overwrite') {
+                const exists = await doesExist(options.bucket, targetFilePath);
 
-                switch (existsBehavior) {
-                    case 'overwrite': {
-                        log.verbose(`File ${targetFilePath} will be overwritten.`);
-                        break;
-                    }
-                    case 'throw': {
+                if (exists) {
+                    if (existsBehavior === 'throw') {
                         throw new Error(
                             `File ${targetFilePath} already exists in ${options.bucket}`,
                         );
                     }
-                    case 'ignore': {
-                        log.message(
-                            `Nothing to do with '${relativeFilePath}' because '${targetFilePath}' already exists in '${options.bucket}'`,
-                        );
-                        return Promise.resolve(relativeFilePath);
-                    }
+
+                    log.message(
+                        `Nothing to do with '${relativeFilePath}' because '${targetFilePath}' already exists in '${options.bucket}'`,
+                    );
+                    return relativeFilePath;
                 }
             }
 

--- a/src/common/s3-upload/upload.ts
+++ b/src/common/s3-upload/upload.ts
@@ -101,9 +101,11 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
                 typeof options.cacheControl === 'function'
                     ? options.cacheControl(targetFilePath)
                     : options.cacheControl;
+            const contentEncoding = getContentEncoding(relativeFilePath);
 
             return uploadFile(options.bucket, sourceFilePath, targetFilePath, {
                 cacheControl,
+                ...(contentEncoding && {contentEncoding}),
             })
                 .then(() => {
                     log.message(`Uploaded ${relativeFilePath} => ${targetFilePath}`);
@@ -174,6 +176,17 @@ function getRelativeFilePath(sourcePath: string, filePath: string) {
 
 function toPosixPath(filePath: string) {
     return filePath.split(path.sep).join(path.posix.sep);
+}
+
+function getContentEncoding(filePath: string) {
+    switch (path.extname(filePath).toLowerCase()) {
+        case '.gz':
+            return 'gzip';
+        case '.br':
+            return 'br';
+        default:
+            return undefined;
+    }
 }
 
 function isNotFoundError(error: unknown) {

--- a/src/common/s3-upload/upload.ts
+++ b/src/common/s3-upload/upload.ts
@@ -44,11 +44,17 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
         }),
     );
 
-    function doesExist(bucket: string, key: string): Promise<boolean> {
-        return queue
-            .add(() => s3Client.headObject(bucket, key))
-            .then(() => true)
-            .catch(() => false);
+    async function doesExist(bucket: string, key: string): Promise<boolean> {
+        try {
+            await queue.add(() => s3Client.headObject(bucket, key));
+            return true;
+        } catch (error) {
+            if (isNotFoundError(error)) {
+                return false;
+            }
+
+            throw error;
+        }
     }
 
     function uploadFile(
@@ -148,6 +154,23 @@ export async function uploadFiles(files: string[], config: UploadFilesOptions) {
 }
 
 const NOT_COMPRESS = ['png', 'zip', 'gz', 'br'];
+
+function isNotFoundError(error: unknown) {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const s3Error = error as {
+        name?: string;
+        $metadata?: {httpStatusCode?: number};
+    };
+
+    return (
+        s3Error.$metadata?.httpStatusCode === 404 ||
+        s3Error.name === 'NotFound' ||
+        s3Error.name === 'NoSuchKey'
+    );
+}
 
 function shouldCompress(filePath: string) {
     const fileName = path.basename(filePath);


### PR DESCRIPTION
Main reason - incorrect `already exists` status, when happen network error with s3
Add retry params for s3 client
Add content-encoding header
Add skip head request, when overwrite s3 mode
Add posix path validation
