### PR TITLE
fix: resolve import exports for unknown Rspack dependencies

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -51,6 +51,7 @@ import type {ForkTsCheckerWebpackPluginOptions} from 'fork-ts-checker-webpack-pl
 import type {moduleFederationPlugin} from '@module-federation/enhanced';
 import {hasMFAssetsIsolation} from '../utils.js';
 import {StatoscopePlugin} from './statoscope-plugin.js';
+import {getByDependencyResolveOptions} from './resolve.js';
 
 const imagesSizeLimit = 2048;
 const fontSizeLimit = 8192;
@@ -460,6 +461,7 @@ export function configureResolve({isEnvProduction, config}: HelperOptions) {
         extensions: ['.mjs', '.cjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
         symlinks: config.symlinks,
         fallback: config.fallback,
+        byDependency: getByDependencyResolveOptions(config.bundler),
     } satisfies webpack.ResolveOptions;
 }
 

--- a/src/common/webpack/resolve.test.ts
+++ b/src/common/webpack/resolve.test.ts
@@ -1,0 +1,15 @@
+import {getByDependencyResolveOptions} from './resolve.js';
+
+describe('dependency resolve configuration', () => {
+    it('enables import conditional exports for unknown Rspack dependencies', () => {
+        expect(getByDependencyResolveOptions('rspack')).toEqual({
+            unknown: {
+                conditionNames: ['import', 'require', 'module', '...'],
+            },
+        });
+    });
+
+    it('keeps Webpack dependency conditions unchanged', () => {
+        expect(getByDependencyResolveOptions('webpack')).toBeUndefined();
+    });
+});

--- a/src/common/webpack/resolve.ts
+++ b/src/common/webpack/resolve.ts
@@ -1,0 +1,13 @@
+import type {Bundler} from '../models/index.js';
+
+export function getByDependencyResolveOptions(bundler: Bundler) {
+    if (bundler !== 'rspack') {
+        return undefined;
+    }
+
+    return {
+        unknown: {
+            conditionNames: ['import', 'require', 'module', '...'],
+        },
+    };
+}


### PR DESCRIPTION
## What

- Add the `import` condition to Rspack resolution for dependencies classified as `unknown`.
- Keep the existing `require` and `module` conditions.
- Leave Webpack resolution unchanged.

## Why

A JavaScript package can contain ESM imports while omitting `type: module`. Rspack may classify a nested dependency from such a package as `unknown`. When that dependency targets a public package subpath with separate `import` and `require` exports, the ESM branch is not considered and resolution can fail.

Scoping the additional condition to `byDependency.unknown` fixes this case without changing resolution conditions globally.

## Reproduction example

`@gravity-ui/chartkit@8.1.0` is an affected real-world package. Its Yagr plugin imports the public `@gravity-ui/yagr/react` subpath, with `@gravity-ui/yagr@5.2.0` selected in the dependency graph.

An application built with Rspack can fail while bundling this dependency graph:

```
Package subpath './dist/react' is not defined by "exports" in @gravity-ui/yagr/package.json
```

With the `import` condition enabled for `unknown` dependencies, Rspack selects Yagr's public ESM export and the same dependency graph builds successfully.

## Testing

- `pnpm test --runInBand`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm --filter "@examples/*" build`
